### PR TITLE
Correction de l'affichage des fichiers de l'API

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,5 +1,7 @@
 RewriteEngine on
 RewriteCond %{REQUEST_METHOD} =GET
+RewriteRule ^$ src/riendutout [B,L]
+RewriteCond %{REQUEST_METHOD} =GET
 RewriteRule ^([a-zA-Z0-9_]+)$ src/index.php?table=$1 [B,L]
 RewriteCond %{REQUEST_METHOD} =GET
 RewriteRule ^([a-zA-Z0-9_]+)/({.*})$ src/index.php?table=$1&champs=$2 [B,L]

--- a/src/MyAccessBDD.php
+++ b/src/MyAccessBDD.php
@@ -61,10 +61,10 @@ class MyAccessBDD extends AccessBDD {
                 return $this->selectAbonnementsRevue($champs);
             case "utilisateur":
                 if($this->selecUtilisateurValide($champs)){
-                    return $this->selecUtilisateurValide($champs); //On retourne une liste vide au lieu de null pour laisser savoir au logiciel que l'authentification a réussi.
+                    return $this->selecUtilisateurValide($champs);
                 }
                 else{
-                    return null; //On retourne null pour laisser savoir au logiciel que l'authentification a raté.
+                    return null;
                 }
             default:
                 // cas général


### PR DESCRIPTION
On a désormais une erreur 404 au lieu d'avoir la liste des fichiers de l'API en tentant d'accéder à l'adresse de l'API sans paramètre :
[http://localhost/rest_mediatekdocuments/](http://localhost/rest_mediatekdocuments/ )